### PR TITLE
fix for mixed content blocked, and .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Dependency directories
+node_modules/
+
+# results
+dist/
+

--- a/src/partials/head.ejs
+++ b/src/partials/head.ejs
@@ -15,6 +15,6 @@
 	<link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700" rel="stylesheet">
 
 	<!-- d3  -->
-	<script src="http://d3js.org/d3.v3.min.js" type="text/javascript"></script>
+	<script src="//d3js.org/d3.v3.min.js" type="text/javascript"></script>
 	<script src="https://d3js.org/d3-queue.v2.min.js" type="text/javascript"></script>
 </head>


### PR DESCRIPTION
When this is used on a site that is https only, d3js.org/d3.v3.min.js will get blocked. I also added a .gitignore file.